### PR TITLE
docs: fix README content issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build](https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.commerce.taxes/actions/workflows/ci.yml/badge.svg)](https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.commerce.taxes/actions/workflows/ci.yml)
 [![GitHub Last Commit](https://img.shields.io/github/last-commit/ballerina-platform/module-ballerinax-hubspot.crm.commerce.taxes.svg)](https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.commerce.taxes/commits/master)
-[![GitHub Issues](https://img.shields.io/github/issues/ballerina-platform/ballerina-library/module/hubspot.crm.commerce.taxes.svg?label=Open%20Issues)](https://github.com/ballerina-platform/ballerina-library/labels/module%hubspot.crm.commerce.taxes)
+[![GitHub Issues](https://img.shields.io/github/issues/ballerina-platform/ballerina-library/module/hubspot.crm.commerce.taxes.svg?label=Open%20Issues)](https://github.com/ballerina-platform/ballerina-library/labels/module%2Fhubspot.crm.commerce.taxes)
 
 ## Overview
 


### PR DESCRIPTION
## Purpose

Fix documentation issues identified in the HubSpot connector revamp audit.

### README (top-level)

- Fix the encoding bug in the GitHub Issues badge link: `module%hubspot.crm.commerce.taxes` -> `module%2Fhubspot.crm.commerce.taxes`.

The other three systemic README fixes from the audit (`Hubspot` mis-casing, `ave` -> `have` typo, duplicated `Ballerina` in the title) did not match anywhere in this repo's READMEs; nothing else was changed. `ballerina/README.md` has no Issues badge and no other systemic issues, so it is untouched.

## Examples

N/A - documentation-only change to `README.md`.

## Checklist
- [x] Linked to an issue (Refs `ballerina-platform/ballerina-library#8823`)
- [ ] Updated the changelog - N/A (docs-only)
- [ ] Added tests - N/A (docs-only)
- [ ] Updated the spec - N/A (docs-only)
- [x] Checked native-image compatibility - N/A (no code change)

Refs ballerina-platform/ballerina-library#8823